### PR TITLE
Bugfix: Remove non-infobox pushpins

### DIFF
--- a/src/components/BingMapsReact.jsx
+++ b/src/components/BingMapsReact.jsx
@@ -57,6 +57,7 @@ export default function BingMapsReact({
 
   // add pushpins
   function addPushpins(pushPinsToAdd, map, Maps) {
+    removePushpins(map, Maps);
     pushPinsToAdd.forEach((pushPin) => {
       if (pushPin === null) {
         return;


### PR DESCRIPTION
The `pushpins` prop was not correctly removing pushpins when they were
reassigned. This adjusts the prop to behave the same as the
`pushpinsWithInfoboxes` prop.